### PR TITLE
Support the latest AtWiki spec

### DIFF
--- a/atwiki/test/test_core.py
+++ b/atwiki/test/test_core.py
@@ -34,7 +34,7 @@ class AtWikiAPITest(TestCase):
   def test_get_source(self):
     self.assertEqual(self._api.get_source(14, 0),
                      'テスト1\nテスト2\n\nテスト3\nテスト4\n\n\nテスト5')
-    self.assertEqual(self._api.get_source(14, 1),
+    self.assertEqual(self._api.get_source(14, 3),
                      'テスト1\nテスト2\n\nテスト3\nテスト4')
 
   def test_get_source_special(self):

--- a/atwiki/test/test_core.py
+++ b/atwiki/test/test_core.py
@@ -93,9 +93,11 @@ class PagerizeTest(TestCase):
         soup = self._api._request(self._uri.tag('曲', index=1))
         last_index = 1
         for link in soup.find('div', class_='cmd_tag').find_all('a'):
-            if not link.attrs['href'].endswith('&p={}'.format(last_index + 1)):
+            if not link.attrs['href'].endswith('?p={}'.format(last_index + 1)):
                 break
             last_index += 1
+        assert 750 <= last_index
+
         pages = list(self._api.get_list('曲', _start=last_index))
         assert 1 <= len(pages) <= 50
 

--- a/atwiki/test/test_uri.py
+++ b/atwiki/test/test_uri.py
@@ -18,7 +18,7 @@ class AtWikiURITest(TestCase):
     uri = AtWikiURI(base)
 
     self.assertEqual(uri.get_page_id_from_uri('{0}/backupx/123/list.html'.format(base)), 123)
-    self.assertEqual(uri.get_page_id_from_uri('{0}/?cmd=backup&action=show&pageid=456&num=1'.format(base)), 456)
+    self.assertEqual(uri.get_page_id_from_uri('{0}/?cmd=backup&action=show&pageid=456&num=0'.format(base)), 456)
     self.assertEqual(uri.get_page_id_from_uri('{0}/pages/789.html'.format(base)), 789)
 
   def test_path_output(self):
@@ -43,10 +43,10 @@ class AtWikiURITest(TestCase):
 
     self.assertEqual(uri.backup_list(), '{0}/?cmd=backup&action=list'.format(base))
     self.assertEqual(uri.backup_list(10), '{0}/?cmd=backup&action=list&pageid=10'.format(base))
-    self.assertEqual(uri.backup_source(10, 1), '{0}/?cmd=backup&action=source&pageid=10&num=1'.format(base))
-    self.assertEqual(uri.backup_show(10, 1), '{0}/?cmd=backup&action=show&pageid=10&num=1'.format(base))
-    self.assertEqual(uri.backup_diff(10, 1), '{0}/?cmd=backup&action=diff&pageid=10&num=1'.format(base))
-    self.assertEqual(uri.backup_nowdiff(10, 1), '{0}/?cmd=backup&action=nowdiff&pageid=10&num=1'.format(base))
+    self.assertEqual(uri.backup_source(10, 1), '{0}/?cmd=backup&action=source&pageid=10&id=1'.format(base))
+    self.assertEqual(uri.backup_show(10, 1), '{0}/?cmd=backup&action=show&pageid=10&id=1'.format(base))
+    self.assertEqual(uri.backup_diff(10, 1), '{0}/?cmd=backup&action=diff&pageid=10&id=1'.format(base))
+    self.assertEqual(uri.backup_nowdiff(10, 1), '{0}/?cmd=backup&action=nowdiff&pageid=10&id=1'.format(base))
 
     self.assertEqual(uri.page(10), '{0}/pages/10.html'.format(base))
     self.assertEqual(uri.diff(10), '{0}/diffx/10.html'.format(base))

--- a/atwiki/uri.py
+++ b/atwiki/uri.py
@@ -98,7 +98,7 @@ class AtWikiURI(object):
     if page_id is not None:
       url += '&pageid={0}'.format(page_id)
     if generation is not None:
-      url += '&num={0}'.format(generation)
+      url += '&id={0}'.format(generation)
     return url
 
   def backup_list(self, page_id=None):


### PR DESCRIPTION
The generation number must now be specified using `id` (`0` indicating the latest, `1+` indicating the generation number (the oldest is `1`)), instead of `num` (`0` indicating the latest, `1+` indicating the revision count from the latest).